### PR TITLE
Enable Claude GitHub Actions

### DIFF
--- a/v2/.github/workflows/claude.yml
+++ b/v2/.github/workflows/claude.yml
@@ -1,0 +1,16 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Claude Code GitHub Action
+        uses: anthropic/claude-github-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Adds Claude GitHub Actions workflow to allow @claude commands in PRs and issues.